### PR TITLE
Some int type variable overflow

### DIFF
--- a/clipper/fastq-multx.cpp
+++ b/clipper/fastq-multx.cpp
@@ -25,7 +25,7 @@ THE SOFTWARE.
 See "void usage" below for usage.
 
 */
-#include <cinttypes>
+
 #include "fastq-lib.h"
 
 #define MAX_BARCODE_NUM 6000
@@ -1074,7 +1074,7 @@ int main (int argc, char **argv) {
 	printf("Id\tCount\tFile(s)\n");
 	uint64_t tot=0;
 	for (i=0;i<=bcnt;++i) {
-		printf("%s\t%" PRIu64, bc[i].id.s, bc[i].cnt);
+		printf("%s\t%lu", bc[i].id.s, bc[i].cnt);
 		tot+=bc[i].cnt;
 		for (j=0;j<f_n;++j) {
 			if (bc[i].out[j])
@@ -1082,7 +1082,7 @@ int main (int argc, char **argv) {
 		}
 		printf("\n");
 	}
-	printf("total\t%" PRIu64 "\n", tot);
+	printf("total\t%lu\n", tot);
 
     if (!io_ok)
         return 3;

--- a/clipper/fastq-stats.cpp
+++ b/clipper/fastq-stats.cpp
@@ -25,7 +25,6 @@ const char * VERSION = "1.01 $Id$";
 
 #include <ctype.h>
 #include <stdio.h>
-#include <cinttypes>
 
 void usage( FILE * f ) {
   fprintf( f,
@@ -567,7 +566,7 @@ int main( int argc, char**argv ) {
 	if(gc) {
         // put these where they belong
 		if (debug)
-			printf("gcTotal\t%" PRIu64 "\tgcSum\t%f\n\n", gcTotal, gcSum);
+			printf("gcTotal\t%lu\tgcSum\t%f\n\n", gcTotal, gcSum);
         printf("pct-gc cycle-max\t%d\n", gcCyclemax);
         printf("pct-gc mean\t%.2f\n", 100.0 * gcSum / gcTotal);
     }


### PR DESCRIPTION
The maximal number of int type is 2,147,483,648. But now some number could be 5 billion or bigger.
Changed those variables to type uint64_t